### PR TITLE
Upgrade JNA dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -522,7 +522,7 @@ dependencies {
 
     // jna is library for invoking native functions
     // used in the readonly store
-    compile 'net.java.dev.jna:jna:3.2.7'
+    compile 'net.java.dev.jna:jna:5.11.0'
 
     // joda time is replacement for Java Date and Time
     // used in readonly store code.

--- a/src/java/voldemort/store/memory/CacheStorageConfiguration.java
+++ b/src/java/voldemort/store/memory/CacheStorageConfiguration.java
@@ -28,7 +28,7 @@ import voldemort.store.StoreDefinition;
 import voldemort.utils.ByteArray;
 import voldemort.versioning.Versioned;
 
-import com.google.common.collect.MapMaker;
+import com.google.common.cache.CacheBuilder;
 
 /**
  * Identical to the InMemoryStorageConfiguration except that it creates google
@@ -50,8 +50,9 @@ public class CacheStorageConfiguration implements StorageConfiguration {
 
     public StorageEngine<ByteArray, byte[], byte[]> getStore(StoreDefinition storeDef,
                                                              RoutingStrategy strategy) {
-        ConcurrentMap<ByteArray, List<Versioned<byte[]>>> backingMap = new MapMaker().softValues()
-                                                                                     .makeMap();
+        ConcurrentMap<ByteArray, List<Versioned<byte[]>>> backingMap = 
+            CacheBuilder.newBuilder().<ByteArray, List<Versioned<byte[]>>>build().asMap();
+
         return new InMemoryStorageEngine<ByteArray, byte[], byte[]>(storeDef.getName(), backingMap);
     }
 

--- a/src/java/voldemort/store/memory/CacheStorageConfiguration.java
+++ b/src/java/voldemort/store/memory/CacheStorageConfiguration.java
@@ -51,7 +51,10 @@ public class CacheStorageConfiguration implements StorageConfiguration {
     public StorageEngine<ByteArray, byte[], byte[]> getStore(StoreDefinition storeDef,
                                                              RoutingStrategy strategy) {
         ConcurrentMap<ByteArray, List<Versioned<byte[]>>> backingMap = 
-            CacheBuilder.newBuilder().<ByteArray, List<Versioned<byte[]>>>build().asMap();
+            CacheBuilder.newBuilder()
+                .softValues()
+                .<ByteArray, List<Versioned<byte[]>>>build()
+                .asMap();
 
         return new InMemoryStorageEngine<ByteArray, byte[], byte[]>(storeDef.getName(), backingMap);
     }


### PR DESCRIPTION
## Summary

- Upgrades JNA to 5.11.0
- Replaces deprecated `MapMaker` usage