### PR TITLE
NAVY-979 - Publish Voldemort artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2.1
+
+jobs:
+  publish:
+    docker:
+      - image: cimg/openjdk:8.0-browsers
+    steps:
+      - checkout
+      - run:
+          name: publish
+          command: |
+            set +e
+            echo 'Publishing Voldemort artifacts...'
+            ./gradlew artifactoryPublish
+            echo 'Publishing complete!'
+
+workflows:
+  version: 2
+  publish:
+    jobs:
+      - publish:
+          name: publish
+          context: org-global-cph
+          filters:
+            branches:
+              only: master

--- a/build.gradle
+++ b/build.gradle
@@ -463,7 +463,7 @@ allprojects {
     }
 }
 
-task wrapper(type: Wrapper) { gradleVersion = '2.9' }
+task wrapper(type: Wrapper) { gradleVersion = '4.10.3' }
 
 dependencies {
     // Avro serialization format

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,43 @@
-apply plugin: 'java'
-apply plugin: 'war'
-
 buildscript {
     repositories { jcenter() }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.+'
     }
 }
 
+apply plugin: 'java'
+apply plugin: 'war'
 apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
+
+artifactory {
+    contextUrl = 'https://liveintent.jfrog.io/liveintent'
+    publish {
+        defaults {
+            publications('mavenJava')
+        }
+        repository {
+            repoKey = 'sbt'
+            username = System.getenv('ARTIFACTORY_USERNAME')
+            password = System.getenv('ARTIFACTORY_PASSWORD')
+            maven = true
+        }
+    }
+}
+
+artifactoryPublish {
+    dependsOn shadowJar
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}
 
 def String getProjectProperty(String propertyName) {
     String propertyValue = "null"

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,4 +42,4 @@ tomcat.context=/voldemort
 javac.version=1.7
 
 ## Release
-curr.release=1.10.26
+curr.release=1.10.27

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Nov 28 23:14:50 GMT 2015
+#Tue Aug 01 10:35:55 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip


### PR DESCRIPTION
### Summary

- Upgraded Gradle to 4.10.3 (this is the "newest compatible" version supported by the Artifactory plugin)
- Enabled publishing